### PR TITLE
Remove unused xml

### DIFF
--- a/static/icons/youtube-logo.svg
+++ b/static/icons/youtube-logo.svg
@@ -2,7 +2,6 @@
   SPDX-License-Identifier: LicenseRef-YouTube-Brand-Resources
   SPDX-FileCopyrightText: YouTube, Inc. <https://www.youtube.com>
 -->
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
Closes #10 

This xml-definition was the part of the original svg-file and is not needed in this project. This line was left in the code unintentionally. Fixed.